### PR TITLE
fix:  syntax error in vacuum_full_analyze.sh

### DIFF
--- a/utilities/vacuum_full_analyze.sh
+++ b/utilities/vacuum_full_analyze.sh
@@ -6,10 +6,9 @@ fi
 
 DBNAME="testdb"  ###<<<<<<<<<<<<<<<<<< Need to modify database name
 
-
 DATE="/bin/date"
 ECHO="/bin/echo"
-LOGFILE="/data/dba/utilities/log/vacuum_full_analyze_`date '+%Y-%m-%d'`.log"
+LOGFILE=/data/dba/utilities/log/vacuum_full_analyze_`date '+%Y-%m-%d'`.log
 
 $ECHO "  CATALOG TABLE VACUUM ANALYZE started at " > $LOGFILE
 $DATE >> $LOGFILE 


### PR DESCRIPTION
I don't know why the script will report a syntax error in centos7.

```
vacuum_full_analyze_xxxx.log: No such file
```

When I removed the quotes, it was okay.
